### PR TITLE
Distortion textures disable sRGB sampling

### DIFF
--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -240,8 +240,8 @@ public class LeapImageRetriever : MonoBehaviour
       dist_pixelsY_ = new Color32[width * height];
       DestroyImmediate(distortionX_);
       DestroyImmediate(distortionY_);
-      distortionX_ = new Texture2D(width, height, TextureFormat.RGBA32, false);
-      distortionY_ = new Texture2D(width, height, TextureFormat.RGBA32, false);
+      distortionX_ = new Texture2D(width, height, TextureFormat.RGBA32, false, true);
+      distortionY_ = new Texture2D(width, height, TextureFormat.RGBA32, false, true);
       distortionX_.wrapMode = TextureWrapMode.Clamp;
       distortionY_.wrapMode = TextureWrapMode.Clamp;
     }


### PR DESCRIPTION
The distortion textures used in image passthrough had not disabled sRGB sampling, which causes them to be sampled incorrectly when Unity is in Linear color space.  The simple fix is to disable sRGB sampling for the distortion textures, which Unity luckily provides as an option when constructing the texture.

The documentation names this argument as 'linear', but this is a bit misleading since it simply disables sRGB sampling, and does *not* force the texture to behave in linear space.

To test, first load up the PassthroughWithTracking scene and verify that passthrough works normally.  Then go to Edit->ProjectSettings->Player->SettingsForPC/Mac/Linux->OtherSettings and set Color Space to Linear.  Verify that the passthrough scene is now broken (passthrough appears distorted and in the wrong location).  Once you checkout the PR changes passthrough should work in both Linear and Gamma color space.  