### PR TITLE
Add explicit casts to GameObject after Instantiate calls. 

### DIFF
--- a/Assets/LeapMotion+OVR/DemoResources/Scripts/BlocksPlaneGenerator.cs
+++ b/Assets/LeapMotion+OVR/DemoResources/Scripts/BlocksPlaneGenerator.cs
@@ -62,7 +62,7 @@ public class BlocksPlaneGenerator : MonoBehaviour
         radius * Mathf.Cos(theta)
         );
 
-      GameObject cube = GameObject.Instantiate(CubePrimitive);
+      GameObject cube = GameObject.Instantiate(CubePrimitive) as GameObject;
       cube.transform.parent = transform;
       cube.transform.rotation = Quaternion.Euler(Random.Range(0.0f, 360.0f), Random.Range(0.0f, 360.0f), Random.Range(0.0f, 360.0f));
       cube.transform.localScale = Vector3.one * Random.Range(0.1f, size);

--- a/Assets/LeapMotion+OVR/DemoResources/Scripts/RandomBlocksGenerator.cs
+++ b/Assets/LeapMotion+OVR/DemoResources/Scripts/RandomBlocksGenerator.cs
@@ -75,7 +75,7 @@ public class RandomBlocksGenerator : MonoBehaviour {
         radius * Mathf.Cos(theta)
         );
 
-      GameObject cube = GameObject.Instantiate(CubePrimitive);
+      GameObject cube = GameObject.Instantiate(CubePrimitive) as GameObject;
       cube.transform.parent = transform;
       cube.transform.rotation = Quaternion.Euler(Random.Range(0.0f, 360.0f), Random.Range(0.0f, 360.0f), Random.Range(0.0f, 360.0f));
       cube.transform.localScale = Vector3.one * size;


### PR DESCRIPTION
Previous code works in Unity5.x and fails in Unity4.x