### PR TITLE
Changed depth variant shaders to use material keywords

### DIFF
--- a/Assets/LeapMotion/Resources/ImageHandHighlight.shader
+++ b/Assets/LeapMotion/Resources/ImageHandHighlight.shader
@@ -17,7 +17,7 @@ Shader "LeapMotion/Passthrough/ImageHandHighlight" {
 
   CGINCLUDE
   #pragma multi_compile LEAP_FORMAT_IR LEAP_FORMAT_RGB
-  #pragma shader_feature USE_DEPTH_TEXTURE
+  #pragma multi_compile _ USE_DEPTH_TEXTURE
   #include "LeapCG.cginc"
   #include "UnityCG.cginc"
 

--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -16,6 +16,7 @@ using Leap;
 public class LeapImageRetriever : MonoBehaviour {
     public const string IR_SHADER_VARIANT_NAME = "LEAP_FORMAT_IR";
     public const string RGB_SHADER_VARIANT_NAME = "LEAP_FORMAT_RGB";
+	public const string DEPTH_TEXTURE_VARIANT_NAME = "USE_DEPTH_TEXTURE";
     public const int IMAGE_WARNING_WAIT = 10;
 
     public enum EYE {
@@ -86,6 +87,12 @@ public class LeapImageRetriever : MonoBehaviour {
                 Debug.LogWarning("Unexpected format type " + _currentFormat);
                 break;
         }
+
+		if (SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.Depth)) {
+			material.EnableKeyword(DEPTH_TEXTURE_VARIANT_NAME);
+		} else {
+			material.DisableKeyword(DEPTH_TEXTURE_VARIANT_NAME);
+		}
 
         imageBasedMaterial.GetComponent<Renderer>().material.SetFloat("_LeapGammaCorrectionExponent", 1.0f / gammaCorrection);
     }

--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -16,7 +16,7 @@ using Leap;
 public class LeapImageRetriever : MonoBehaviour {
     public const string IR_SHADER_VARIANT_NAME = "LEAP_FORMAT_IR";
     public const string RGB_SHADER_VARIANT_NAME = "LEAP_FORMAT_RGB";
-	public const string DEPTH_TEXTURE_VARIANT_NAME = "USE_DEPTH_TEXTURE";
+    public const string DEPTH_TEXTURE_VARIANT_NAME = "USE_DEPTH_TEXTURE";
     public const int IMAGE_WARNING_WAIT = 10;
 
     public enum EYE {
@@ -88,11 +88,11 @@ public class LeapImageRetriever : MonoBehaviour {
                 break;
         }
 
-		if (SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.Depth)) {
-			material.EnableKeyword(DEPTH_TEXTURE_VARIANT_NAME);
-		} else {
-			material.DisableKeyword(DEPTH_TEXTURE_VARIANT_NAME);
-		}
+        if (SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.Depth)) {
+            material.EnableKeyword(DEPTH_TEXTURE_VARIANT_NAME);
+        } else {
+            material.DisableKeyword(DEPTH_TEXTURE_VARIANT_NAME);
+        }
 
         imageBasedMaterial.GetComponent<Renderer>().material.SetFloat("_LeapGammaCorrectionExponent", 1.0f / gammaCorrection);
     }

--- a/Assets/LeapMotion/Scripts/Utils/EnableDepthBuffer.cs
+++ b/Assets/LeapMotion/Scripts/Utils/EnableDepthBuffer.cs
@@ -5,11 +5,6 @@ using System.Collections;
 public class EnableDepthBuffer : MonoBehaviour {
 
     void Awake() {
-        if (SystemInfo.SupportsRenderTextureFormat(RenderTextureFormat.Depth)) {
-            Shader.EnableKeyword("USE_DEPTH_TEXTURE");
-        } else {
-            Shader.DisableKeyword("USE_DEPTH_TEXTURE");
-        }
         GetComponent<Camera>().depthTextureMode = DepthTextureMode.Depth;
     }
 }


### PR DESCRIPTION
Shaders with variants that use the depth texture for effects no longer rely on global shader keywords, but instead have fallen back to using material specific shader keywords.  This is to get around a strange fact where global shader keywords are not having any effect when built in standalone.

To verify, build the ImageHandsTouchCubes scene to standalone and verify that the depth effects can be seen.  

@GabrielHare 