### PR TITLE
Added device type override to Leap Camera Alignment

### DIFF
--- a/Assets/LeapMotion+OVR/Scripts/LeapCameraAlignment.cs
+++ b/Assets/LeapMotion+OVR/Scripts/LeapCameraAlignment.cs
@@ -53,6 +53,9 @@ public class LeapCameraAlignment : MonoBehaviour {
   [HideInInspector]
   public SmoothedFloat imageLatency;
 
+  public bool overrideDeviceType = false;
+  public LeapDeviceType overrideDeviceTypeWith = LeapDeviceType.Invalid;
+
   protected struct TransformData {
     public long leapTime; // microseconds
     public Vector3 position; //meters
@@ -154,7 +157,7 @@ public class LeapCameraAlignment : MonoBehaviour {
       return;
     }
 
-    deviceInfo = handController.GetDeviceInfo ();
+    deviceInfo = (overrideDeviceType) ? new LeapDeviceInfo(overrideDeviceTypeWith) : handController.GetDeviceInfo ();
     if (deviceInfo.type == LeapDeviceType.Invalid) {
       Debug.LogWarning ("Invalid Leap Device");
       enabled = false;


### PR DESCRIPTION
- [ ] Check if devices can be overriden with LeapCameraAlignment in CenterEyeAnchor (e.g. Plug in peripheral, override to dragonfly. Check if baseline is now 0.064 instead of 0.04)