### PR TITLE
Fixed Update Timeline Synchronization 

### DIFF
--- a/Assets/LeapMotion/Scripts/HandController.cs
+++ b/Assets/LeapMotion/Scripts/HandController.cs
@@ -335,6 +335,8 @@ public class HandController : MonoBehaviour {
   }
 
   /**
+   * NOTE: This method should ONLY be called from within a FixedUpdate callback.
+   * 
    * Returns a Frame object that is properly synchronized to the FixedUpdate timeline.
    * 
    * If the recorder object is playing a recording, then the frame is taken directly from the recording,

--- a/Assets/LeapMotion/Scripts/HandController.cs
+++ b/Assets/LeapMotion/Scripts/HandController.cs
@@ -385,7 +385,7 @@ public class HandController : MonoBehaviour {
       prev_graphics_id_ = frame.Id;
     }
 
-    //fixedUpdateDelay contains the maximum delay of this Update cycle
+    //perFrameFixedUpdateOffset_ contains the maximum offset of this Update cycle
     smoothedFixedUpdateOffset_.Update(perFrameFixedUpdateOffset_, Time.deltaTime);
   }
 

--- a/Assets/LeapMotion/Scripts/HandController.cs
+++ b/Assets/LeapMotion/Scripts/HandController.cs
@@ -341,7 +341,7 @@ public class HandController : MonoBehaviour {
    * with no timeline synchronization performed.  Otherwise, the frame comes directly from the Leap Motion
    * Controller.
    */
-  public Frame GetFixedUpdateFrame() {
+  public Frame GetFixedFrame() {
     if (enableRecordPlayback && (recorder_.state == RecorderState.Playing || recorder_.state == RecorderState.Paused))
       return recorder_.GetCurrentFrame();
 
@@ -398,7 +398,7 @@ public class HandController : MonoBehaviour {
     //into Update for smoothing.
     perFrameFixedUpdateOffset_ = leap_controller_.Frame().Timestamp * NS_TO_S - Time.fixedTime;
 
-    Frame frame = GetFixedUpdateFrame();
+    Frame frame = GetFixedFrame();
 
     if (frame.Id != prev_physics_id_) {
       UpdateHandModels(hand_physics_, frame.Hands, leftPhysicsModel, rightPhysicsModel);

--- a/Assets/LeapMotion/Scripts/HandController.cs
+++ b/Assets/LeapMotion/Scripts/HandController.cs
@@ -335,7 +335,7 @@ public class HandController : MonoBehaviour {
   }
 
   /**
-   * This method should ONLY be called from within a FixedUpdate callback.
+   * NOTE: This method should ONLY be called from within a FixedUpdate callback.
    * 
    * Unity Physics runs at a constant frame step, where the physics time between each FixedUpdate is the same. However
    * there is a big difference between the physics timeline and the real timeline.  In Unity, these timelines can be
@@ -368,9 +368,6 @@ public class HandController : MonoBehaviour {
    * 
    * As the graph shows, the GetFixedFrame method can significantly help solve the judder that can occur when sampling
    * controller.Frame while in FixedUpdate.
-   * 
-   * NOTE: This method should only be called during a FixedUpdate.  If it is called from anywhere else the Frame returned
-   * is not guaranteed to make sense.
    * 
    * ALSO: If the recorder object is playing a recording, then the frame is taken directly from the recording,
    * with no timeline synchronization performed.

--- a/Assets/LeapMotion/Scripts/HandController.cs
+++ b/Assets/LeapMotion/Scripts/HandController.cs
@@ -401,7 +401,7 @@ public class HandController : MonoBehaviour {
   }
 
   /** Updates the graphics objects. */
-  void Update() {
+  virtual void Update() {
     if (leap_controller_ == null)
       return;
 
@@ -421,7 +421,7 @@ public class HandController : MonoBehaviour {
   }
 
   /** Updates the physics objects */
-  void FixedUpdate() {
+  virtual void FixedUpdate() {
     if (leap_controller_ == null)
       return;
 

--- a/Assets/LeapMotion/Scripts/HandController.cs
+++ b/Assets/LeapMotion/Scripts/HandController.cs
@@ -401,7 +401,7 @@ public class HandController : MonoBehaviour {
   }
 
   /** Updates the graphics objects. */
-  virtual void Update() {
+  protected virtual void Update() {
     if (leap_controller_ == null)
       return;
 
@@ -421,7 +421,7 @@ public class HandController : MonoBehaviour {
   }
 
   /** Updates the physics objects */
-  virtual void FixedUpdate() {
+  protected virtual void FixedUpdate() {
     if (leap_controller_ == null)
       return;
 

--- a/Assets/LeapMotion/Scripts/HandController.cs
+++ b/Assets/LeapMotion/Scripts/HandController.cs
@@ -32,11 +32,11 @@ public class HandController : MonoBehaviour {
   // Reference distance from thumb base to pinky base in mm.
   protected const float GIZMO_SCALE = 5.0f;
   /** Conversion factor for millimeters to meters. */
-  protected const float MM_TO_M = 0.001f;
+  protected const float MM_TO_M = 1e-3f;
   /** Conversion factor for nanoseconds to seconds. */
-  protected const float NS_TO_S = 0.000001f;
+  protected const float NS_TO_S = 1e-6f;
   /** Conversion factor for seconds to nanoseconds. */
-  protected const float S_TO_NS = 1000000f;
+  protected const float S_TO_NS = 1e6f;
   /** How much smoothing to use when calculating the FixedUpdate offset. */
   protected const float FIXED_UPDATE_OFFSET_SMOOTHING_DELAY = 0.1f;
 

--- a/Assets/LeapMotion/Scripts/HandController.cs
+++ b/Assets/LeapMotion/Scripts/HandController.cs
@@ -346,7 +346,7 @@ public class HandController : MonoBehaviour {
       return recorder_.GetCurrentFrame();
 
     //Aproximate the correct timestamp given the current fixed time
-    float correctedTimestamp = (Time.fixedTime - smoothedFixedUpdateOffset_.value) * S_TO_NS;
+    float correctedTimestamp = (Time.fixedTime + smoothedFixedUpdateOffset_.value) * S_TO_NS;
 
     //Search the leap history for a frame with a timestamp closest to the corrected timestamp
     Frame closestFrame = leap_controller_.Frame();
@@ -396,7 +396,7 @@ public class HandController : MonoBehaviour {
 
     //All FixedUpdates of a frame happen before Update, so only the last of these calculations is passed
     //into Update for smoothing.
-    perFrameFixedUpdateOffset_ = Time.fixedTime - leap_controller_.Frame().Timestamp * NS_TO_S;
+    perFrameFixedUpdateOffset_ = leap_controller_.Frame().Timestamp * NS_TO_S - Time.fixedTime;
 
     Frame frame = GetFixedUpdateFrame();
 


### PR DESCRIPTION
The FixedUpdate timeline is distorted relative to the LeapTimeline.  This is especially apparent in situations where the physics framerate is higher than the update framerate.  I have added a method GetFixedFrame() which returns a frame accounting for the timeline distortion/offset, which reduces jitter and improves smoothness.

This is difficult to verify without some sort of visualization, so it might be a good idea to pop over to my desk and I can show you how I use the Squiggle utility in HandyTools to verify it is working.

@yuwilbur 
@GabrielHare 
@RandomOutput 