### PR TITLE
Temporary hack for device type

### DIFF
--- a/Assets/LeapMotion/Scripts/HandController.cs
+++ b/Assets/LeapMotion/Scripts/HandController.cs
@@ -447,7 +447,8 @@ public class HandController : MonoBehaviour {
   public LeapDeviceInfo GetDeviceInfo() {
     DeviceList devices = leap_controller_.Devices;  
     if (devices.Count == 1) {
-      LeapDeviceInfo info = new LeapDeviceInfo(LeapDeviceType.Invalid);
+      LeapDeviceInfo info = new LeapDeviceInfo(LeapDeviceType.Peripheral);
+
       // TODO: DeviceList does not tell us the device type. Dragonfly serial starts with "LE" and peripheral starts with "LP"
       if (devices[0].SerialNumber.Length >= 2) {
         switch (devices[0].SerialNumber.Substring(0, 2)) {


### PR DESCRIPTION
Until we can actually get a propper way to determine device type (since no API call can currently tell us) the method used will default to the peripheral instead of Invalid device type.  This is to handle cases where the serial number rule @yuwilbur was using fails to recognize a device.

To test, just verify that a demo scene works properly.  Before this PR it would spit out warnings about invalid devices (probably depending on the device)

@RandomOutput 
@protodeep 