### PR TITLE
Allow distortion to be recalculated properly

### DIFF
--- a/Assets/LeapMotion/Scripts/LeapHandController.cs.meta
+++ b/Assets/LeapMotion/Scripts/LeapHandController.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
 guid: 215a4d49fc705b74a9d3c5cbfa2c9601
-timeCreated: 1455315371
-licenseType: Free
+timeCreated: 1455681390
+licenseType: Pro
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 100
+  executionOrder: -1000
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs.meta
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs.meta
@@ -1,8 +1,12 @@
 fileFormatVersion: 2
 guid: fd815635398474cbbba564563a209f82
+timeCreated: 1455681390
+licenseType: Pro
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -1000
   icon: {instanceID: 0}
   userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Scripts/LeapProvider.cs
+++ b/Assets/LeapMotion/Scripts/LeapProvider.cs
@@ -5,36 +5,35 @@ using Leap;
 
 namespace Leap {
   public class LeapProvider :
-    MonoBehaviour
-  {
+    MonoBehaviour {
     public Frame CurrentFrame { get; private set; }
     public Image CurrentImage { get; private set; }
     private Transform providerSpace;
     private Matrix leapMat;
 
-    public Controller leap_controller_ { get; set; }
+    protected Controller leap_controller_;
 
     /** The smoothed offset between the FixedUpdate timeline and the Leap timeline.  
    * Used to provide temporally correct frames within FixedUpdate */
-  private SmoothedFloat smoothedFixedUpdateOffset_ = new SmoothedFloat();
-  /** The maximum offset calculated per frame */
-  public float PerFrameFixedUpdateOffset;
-     /** Conversion factor for millimeters to meters. */
-  protected const float MM_TO_M = 1e-3f;
-  /** Conversion factor for nanoseconds to seconds. */
-  protected const float NS_TO_S = 1e-6f;
-  /** Conversion factor for seconds to nanoseconds. */
-  protected const float S_TO_NS = 1e6f;
-  /** How much smoothing to use when calculating the FixedUpdate offset. */
-  protected const float FIXED_UPDATE_OFFSET_SMOOTHING_DELAY = 0.1f;
+    private SmoothedFloat smoothedFixedUpdateOffset_ = new SmoothedFloat();
+    /** The maximum offset calculated per frame */
+    public float PerFrameFixedUpdateOffset;
+    /** Conversion factor for millimeters to meters. */
+    protected const float MM_TO_M = 1e-3f;
+    /** Conversion factor for nanoseconds to seconds. */
+    protected const float NS_TO_S = 1e-6f;
+    /** Conversion factor for seconds to nanoseconds. */
+    protected const float S_TO_NS = 1e6f;
+    /** How much smoothing to use when calculating the FixedUpdate offset. */
+    protected const float FIXED_UPDATE_OFFSET_SMOOTHING_DELAY = 0.1f;
 
-  /** Set true if the Leap Motion hardware is mounted on an HMD; otherwise, leave false. */
-  public bool isHeadMounted = false;
+    /** Set true if the Leap Motion hardware is mounted on an HMD; otherwise, leave false. */
+    public bool isHeadMounted = false;
 
-  public bool overrideDeviceType = false;
+    public bool overrideDeviceType = false;
 
-  /** If overrideDeviceType is enabled, the hand controller will return a device of this type. */
-  public LeapDeviceType overrideDeviceTypeWith = LeapDeviceType.Peripheral;
+    /** If overrideDeviceType is enabled, the hand controller will return a device of this type. */
+    public LeapDeviceType overrideDeviceTypeWith = LeapDeviceType.Peripheral;
 
     void Awake() {
       leap_controller_ = new Controller();
@@ -55,8 +54,7 @@ namespace Leap {
       InitializeFlags();
     }
 
-    protected void OnDisable()
-    {
+    protected void OnDisable() {
       leap_controller_.Device -= HandleControllerConnect;
     }
 
@@ -118,8 +116,7 @@ namespace Leap {
         info.trackingRange = devices[0].Range / 1000f;
         info.serialID = devices[0].SerialNumber;
         return info;
-      }
-      else if (devices.Count > 1) {
+      } else if (devices.Count > 1) {
         return new LeapDeviceInfo(LeapDeviceType.Peripheral);
       }
       return new LeapDeviceInfo(LeapDeviceType.Invalid);
@@ -168,13 +165,12 @@ namespace Leap {
 
         if (Mathf.Abs(historyFrame.Timestamp - correctedTimestamp) < Mathf.Abs(closestFrame.Timestamp - correctedTimestamp)) {
           closestFrame = historyFrame;
-        }
-        else {
+        } else {
           //Since frames are always reported in order, we can terminate the search once we stop finding a closer frame
           break;
         }
       }
-      return closestFrame; 
+      return closestFrame;
     }
     void OnDestroy() {
       //DestroyAllHands();

--- a/Assets/LeapMotion/Scripts/LeapProvider.cs.meta
+++ b/Assets/LeapMotion/Scripts/LeapProvider.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
 guid: 025cc0fa7b46aa541aba29d28d35ac09
-timeCreated: 1455315371
-licenseType: Free
+timeCreated: 1455681390
+licenseType: Pro
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -1001
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Assets/LeapMotionVR/Scenes.meta
+++ b/Assets/LeapMotionVR/Scenes.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 592e402dd24e6fa4a82f231a3c3546e0
-folderAsset: yes
-timeCreated: 1454460606
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/LeapMotionVR/Scripts.meta
+++ b/Assets/LeapMotionVR/Scripts.meta
@@ -1,5 +1,0 @@
-fileFormatVersion: 2
-guid: 46d65e1267b071e45be6c5e2ab3a0300
-folderAsset: yes
-DefaultImporter:
-  userData: 


### PR DESCRIPTION
- LeapImageRetriever subscribes to the DistortionChanged event and marks it's EyeTextureData as stale if it receives an event, causing it to be recalculated once the next image is retrieved.  Previously the distortion data was not ever recalculated, causing misalignment.
- LeapImageRetriever needs to execute after LeapProvider in order to acquire the most recent frame.  An ExecuteAfter attribute has been added to ensure that this was the case.
- The Controller field in LeapProvider was public, it has been changed to protected since there already is a getter method.

@protodeep 