### PR TITLE
IsStale flag is now reset properly

### DIFF
--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -262,6 +262,8 @@ public class LeapImageRetriever : MonoBehaviour {
           Debug.LogWarning("Unexpected format type " + raw.Format);
           break;
       }
+
+      _isStale = false;
     }
 
     public void UpdateTextures(Image bright, Image raw) {


### PR DESCRIPTION
IsStale flag was never set to false, resulting in the eye texture data being recalculated every frame, resulting in lots of garbage and slowdown.  

- [ ] Verify with Unity profiler that with fix that OnPreRender no longer generates tons of garbage and is super slow.

@protodeep 